### PR TITLE
Fix mixed received and transmitted packages with same id can not be parsed correctly

### DIFF
--- a/uavcan_gui_tool/widgets/bus_monitor/transfer_decoder.py
+++ b/uavcan_gui_tool/widgets/bus_monitor/transfer_decoder.py
@@ -47,7 +47,7 @@ def decode_transfer_from_frame(entry_row, row_to_frame):
             raise DecodingFailedException('SOT not found')
         f, d = row_to_frame(row)
         row -= 1
-        if f.id == can_id and _get_transfer_id(f) == transfer_id:
+        if f.id == can_id and _get_transfer_id(f) == transfer_id and d == direction:
             frames.insert(0, f)
             related_rows.insert(0, row)
 
@@ -58,7 +58,7 @@ def decode_transfer_from_frame(entry_row, row_to_frame):
         if f is None or row - entry_row > TABLE_TRAVERSING_RANGE:
             raise DecodingFailedException('EOT not found')
         row += 1
-        if f.id == can_id and _get_transfer_id(f) == transfer_id:
+        if f.id == can_id and _get_transfer_id(f) == transfer_id and d == direction:
             frames.append(f)
             related_rows.append(row)
 

--- a/uavcan_gui_tool/widgets/bus_monitor/transfer_decoder.py
+++ b/uavcan_gui_tool/widgets/bus_monitor/transfer_decoder.py
@@ -33,7 +33,7 @@ def _is_end_of_transfer(frame):
 
 
 def decode_transfer_from_frame(entry_row, row_to_frame):
-    entry_frame = row_to_frame(entry_row)
+    entry_frame, direction = row_to_frame(entry_row)
     can_id = entry_frame.id
     transfer_id = _get_transfer_id(entry_frame)
     frames = [entry_frame]
@@ -45,7 +45,7 @@ def decode_transfer_from_frame(entry_row, row_to_frame):
     while not _is_start_of_transfer(frames[0]):
         if row < 0 or entry_row - row > TABLE_TRAVERSING_RANGE:
             raise DecodingFailedException('SOT not found')
-        f = row_to_frame(row)
+        f, d = row_to_frame(row)
         row -= 1
         if f.id == can_id and _get_transfer_id(f) == transfer_id:
             frames.insert(0, f)
@@ -54,7 +54,7 @@ def decode_transfer_from_frame(entry_row, row_to_frame):
     # Scanning forward looking for the last frame
     row = entry_row + 1
     while not _is_end_of_transfer(frames[-1]):
-        f = row_to_frame(row)
+        f, d = row_to_frame(row)
         if f is None or row - entry_row > TABLE_TRAVERSING_RANGE:
             raise DecodingFailedException('EOT not found')
         row += 1

--- a/uavcan_gui_tool/widgets/bus_monitor/window.py
+++ b/uavcan_gui_tool/widgets/bus_monitor/window.py
@@ -202,6 +202,7 @@ def row_to_frame(table, row_index):
     can_id = None
     payload = None
     extended = None
+    direction = None
 
     for col_index, col_spec in enumerate(COLUMNS):
         item = table.item(row_index, col_index).text()
@@ -210,9 +211,11 @@ def row_to_frame(table, row_index):
             can_id = int(item, 16)
         if col_spec.name == 'Data Hex':
             payload = bytes([int(x, 16) for x in item.split()])
+        if col_spec.name == 'Dir':
+            direction = item.strip()
 
-    assert all(map(lambda x: x is not None, [can_id, payload, extended]))
-    return CANFrame(can_id, payload, extended, ts_monotonic=-1, ts_real=-1)
+    assert all(map(lambda x: x is not None, [can_id, payload, extended, direction]))
+    return CANFrame(can_id, payload, extended, ts_monotonic=-1, ts_real=-1), direction
 
 
 class BusMonitorWindow(QMainWindow):

--- a/uavcan_gui_tool/widgets/bus_monitor/window.py
+++ b/uavcan_gui_tool/widgets/bus_monitor/window.py
@@ -197,7 +197,7 @@ COLUMNS = [
 
 def row_to_frame(table, row_index):
     if row_index >= table.rowCount():
-        return None
+        return None, None
 
     can_id = None
     payload = None


### PR DESCRIPTION
When same kind of packages are send and received at the same time, the parser might not be able to parse the message since the header or the tail of the messages might belong to messages with different directions.

This PR fixes this issue.