### PR TITLE
Fix bug where exception is raised when no response is returned for request in console

### DIFF
--- a/uavcan_gui_tool/main.py
+++ b/uavcan_gui_tool/main.py
@@ -251,6 +251,9 @@ class MainWindow(QMainWindow):
             Formats the argument as YAML structure using uavcan.to_yaml(), and prints the result into stdout.
             Use this function to print received UAVCAN structures.
             """
+            if obj is None:
+                return
+
             print(uavcan.to_yaml(obj))
 
         def throw_if_anonymous():


### PR DESCRIPTION
When calling ```request``` from interactive console, if no response is returned, exception will be raised since ```None``` can not be printed as yaml. It will be nice to print nothing if no response is returned. This PR fixes this issue.

Reproduce:

![image](https://user-images.githubusercontent.com/1401630/92452799-17fb9f00-f1f1-11ea-95c4-33b72b3c1283.png)
