### PR TITLE
Fix spelling of acturator, including the filename.

### DIFF
--- a/uavcan_gui_tool/panels/__init__.py
+++ b/uavcan_gui_tool/panels/__init__.py
@@ -34,5 +34,5 @@ class PanelDescriptor:
 
 PANELS = sorted([
     PanelDescriptor(esc_panel),
-    PanelDescriptor(acturator_panel)
+    PanelDescriptor(actuator_panel)
 ], key=lambda x: x.name)

--- a/uavcan_gui_tool/panels/actuator_panel.py
+++ b/uavcan_gui_tool/panels/actuator_panel.py
@@ -45,8 +45,8 @@ class PercentSlider(QWidget):
         self._spinbox.setSingleStep(0.001)
         self._spinbox.valueChanged.connect(lambda: self._slider.setValue(self._spinbox.value()*1000.0))
 
-        self._zero_button = make_icon_button('hand-stop-o', 'Zero setpoint', self, on_clicked=self.zero)
-        
+        self._zero_button = make_icon_button('hand-stop-o', 'Zero setpoint', self, text = 'Zero', on_clicked=self.zero)
+
         self._actuator_id = QSpinBox(self)
         self._actuator_id.setMinimum(0)
         self._actuator_id.setMaximum(15)
@@ -109,7 +109,7 @@ class ActuatorPanel(QDialog):
         self._bcast_interval.valueChanged.connect(
             lambda: self._bcast_timer.setInterval(self._bcast_interval.value() * 1e3))
 
-        self._stop_all = make_icon_button('hand-stop-o', 'Zero all channels', self, text='Stop All',
+        self._stop_all = make_icon_button('hand-stop-o', 'Zero all channels', self, text='Zero All',
                                           on_clicked=self._do_stop_all)
 
         self._pause = make_icon_button('pause', 'Pause publishing', self, checkable=True, text='Pause')


### PR DESCRIPTION
< facepalm >
The seemingly simple quick fix in https://github.com/UAVCAN/gui_tool/pull/48 just before it merged of fixing the spelling in __init__ needed to be applied to more than just that. I spelled the filename wrong the same way too causing it to not load correctly with the __init__ fix! So, without this fix the develop branch is currently broken. My appologies!
< / facepalm >
